### PR TITLE
Add scroll and spread viewer properties of locale ko

### DIFF
--- a/qpdflib/pdfview/locale/ko/viewer.properties
+++ b/qpdflib/pdfview/locale/ko/viewer.properties
@@ -65,6 +65,20 @@ cursor_text_select_tool_label=텍스트 선택 도구
 cursor_hand_tool.title=손 도구 활성화
 cursor_hand_tool_label=손 도구
 
+scroll_vertical.title=세로 스크롤 사용
+scroll_vertical_label=세로 스크롤
+scroll_horizontal.title=가로 스크롤 사용
+scroll_horizontal_label=가로 스크롤
+scroll_wrapped.title=포장된 스크롤 사용
+scroll_wrapped_label=포장된 스크롤
+
+spread_none.title=한 페이지로 보기
+spread_none_label=한 페이지
+spread_odd.title=홀수 페이지를 기준으로 두 페이지씩 보기
+spread_odd_label=홀수 두 페이지
+spread_even.title=짝수 페이지를 기준으로 두 페이지씩 보기
+spread_even_label=짝수 두 페이지
+
 # Document properties dialog box
 document_properties.title=문서 속성…
 document_properties_label=문서 속성…


### PR DESCRIPTION
Because these properties do not exist, a warning error is output when you create widgets with other locales.
![image](https://github.com/Archie3d/qpdf/assets/56789994/33db351e-84bb-44d6-966b-6e31b318019b)